### PR TITLE
Bulletpoints

### DIFF
--- a/Podcasts.md
+++ b/Podcasts.md
@@ -2,18 +2,18 @@
 
 * Business
   
-[https://www.kalzumeus.com/podcast/](Kalzumeus)
+1. [https://www.kalzumeus.com/podcast/](Kalzumeus)
 
 * Design 
 
-[https://www.relay.fm/presentable](Presentable)
-[https://www.designbetter.co/podcast](DesignBetter.Co)
-[https://spec.fm/podcasts/design-details](Design Details Spec)
+1. [https://www.relay.fm/presentable](Presentable)
+2. [https://www.designbetter.co/podcast](DesignBetter.Co)
+3. [https://spec.fm/podcasts/design-details](Design Details Spec)
 
 * Accesibility
   
-[https://a11yrules.com/](A11y Rules)
-[http://ebuaccesscast.libsyn.com/](EBU Access Cast)
+1. [https://a11yrules.com/](A11y Rules)
+2. [http://ebuaccesscast.libsyn.com/](EBU Access Cast)
 
 * Code
 
@@ -24,4 +24,4 @@
 
 * History, founders on internet
 
-[https://www.redhat.com/en/command-line-heroes](Command Line Heroes)
+1. [https://www.redhat.com/en/command-line-heroes](Command Line Heroes)


### PR DESCRIPTION
Added a numbered list to each section of the podcasts page to help with readability. Previously if more than one podcast was added to a section (e.g. Code) the two podcast names and their addresses would display inline. Please note: I'm new to markdown so do feel free to reject this if I've implemented this incorrectly! @SamirJouni 