### PR TITLE
feat: Create MOOC's section

### DIFF
--- a/Podcasts.md
+++ b/Podcasts.md
@@ -35,7 +35,7 @@
 - [Future of Coding](https://futureofcoding.org/episodes/])
 - [JavaScript Jabber](https://devchat.tv/js-jabber/)
 - [REAL TALK Javascript](https://realtalkjavascript.simplecast.fm/)
-- [Syntax.fm](https://syntax.fm/): By Wes Bos & Scott Tolinksi; covers web development, front-end, but also learning and business.
+- [Syntax.fm](https://syntax.fm/): The amazing Wes Bos & Scott Tolinksi hosts a podcast covering web development, front-end, the process of learning, and business. You can also find their episodes on various apps like Spotify etc.
 
 ## Mindset/Self-Development
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 * [**JavaScript Resources**](JavaScript.md): A list of resources for learning JavaScript.
 
+* [**MOOCs (Massive Open Online Courses)**](moocs.md): Showcasing effective online courses that covers areas such as Full-Stack development, Front-End development, Computer Science, or even a little of everything!
+
 * [**Podcasts**](Podcasts.md): A range of podcasts covering topics like coding, design, accessibility, JavaScript, and Mindset/Self-Development.
 
 * [**Programming Books**](Programming_Books.md): Featuring a list of insightful programming books, both free and paid versions.

--- a/generalResources.md
+++ b/generalResources.md
@@ -1,16 +1,10 @@
 # General Resources for Learning Web Development
 
-- [BitDegree](https://www.bitdegree.org/): Website with free/paid online courses about web development, design, graphics, programming etc.
-
-- [Codecademy](https://www.codecademy.com/catalog/subject/web-development): A place to learn and practice web development concepts and languages.
-
 - [CodePen](https://www.codepen.io/): A development environment for front-end designers and developers, to showcase user-created HTML, CSS and JavaScript code snippets.
 
 - [Codewars](https://www.codewars.com/): A place to challenge yourself and hone your coding skills. See if you can find any fellow ZTM students on there and team up!
 
 - [CodeSignal](https://www.codesignal.com): Formerly CodeFights, this site has real-world coding questions as well as challenges to keep your skills sharp and help you prepare for interviews.
-
-- [Coursera](https://www.coursera.com/): A website for learning from teachers of reputed universities and colleges around the world.
 
 - [CSS Reference](https://cssreference.io/): An online guide to CSS that features complete descriptions, examples of usage, and illustrated/animated examples of the most popular CSS properties.
 
@@ -18,13 +12,7 @@
 
 - [DevHints](https://devhints.io/): A great resource of cheat sheets for a wide range of technologies.
 
-- [edX](https://www.edx.org/): A website with a variety of courses made by schools and such. This does include courses on web development, Python, and other programming languages.
-
-- [egghead](https://egghead.io): A place to learn new web development concepts and languages, both for free and paid.
-
 - [First Aid Git](http://firstaidgit.io): A searchable collection of the most frequently asked Git questions.
-
-- [freeCodeCamp.org](https://www.freecodecamp.org): A free site for learning web development. Optionally, you can pledge to donate money to charities while you learn, giving an incentive to keep working. In particular, this site features a number of [JavaScript algorithms](https://learn.freecodecamp.org/coding-interview-prep/algorithms), [data structures](https://learn.freecodecamp.org/coding-interview-prep/data-structures), [take home projects](https://learn.freecodecamp.org/coding-interview-prep/take-home-projects), and [Rosetta Code problems](https://learn.freecodecamp.org/coding-interview-prep/rosetta-code/) as well as a massive list of [Project Euler problems](https://learn.freecodecamp.org/coding-interview-prep/project-euler), all for practice and preparation for technical job interviews.
 
 - [Frontend Masters](https://frontendmasters.com/): A video tutorial website which are workshop based videos. The videos are expert-level workshops for developers that want to learn the secrets to level up their JavaScript and Node.js engineering skills and many more.
 
@@ -40,34 +28,13 @@
 
 - [Jekyll Cheatsheet](https://learn.cloudcannon.com/jekyll-cheat-sheet/): An excellent resource for learning Jekyll variables and filters.
 
-- [Khan Academy](https://www.khanacademy.org/computing/computer-programming): An online resource for a variety of topics at a multitude of skill levels (from elementary school to postgraduate) that extend beyond computer science. However, their programming courses - which include interactive sandboxes in which learners can tinker with example code - focus on HTML and JavaScript and teach the fundamentals of animation and web design.
-
-- [Learn Enough](https://www.learnenough.com/courses): A comprehensive guide to providing you with a solid foundation as a developer to become comfortable with all of the tools and technologies you interact with. Created by Michael Hartl – founder of Learn Enough and creator of the Ruby on Rails tutorial – these courses are free to read online and available for purchase as an ebook for your device.
-
-- [Microsoft Virtual Academy](https://mva.microsoft.com/): A website with many video courses created by Microsoft. These courses teach a variety of languages, including JavaScript and variants of C.
-
 - [MDN Web Docs](https://developer.mozilla.org/en-US/): A resource for developers, maintained by the community of developers and technical writers and hosting many documents on a wide variety of subjects, such as: HTML, CSS, HTTP, JavaScript, Web APIs, Web components, Graphics, Audio, video and multimedia, MathML.
 
 - [Oh Shit Git](http://ohshitgit.com/): How to get yourself out of mistakes made with Git.
 
-- [Pluralsight](https://www.pluralsight.com): Pluralsight is the leader in training for serious software developers, IT admins, and creative professionals. With 3,000+ courses and new ones added daily, Pluralsight serves as a career catalyst for customers in more than 150 countries and provides tech-savvy businesses with training on the three key areas they need to thrive.
-
-- [SoloLearn](https://www.sololearn.com/): Join the largest community of mobile code learners today. Basically, It's a great app to help you get a basic concept of learning various programming languages easily and those are well structured to learn. It has a very friendly community to join and it's increasing and getting stronger day by day. There is a battle option to compete with others to justify your knowledge. Believe me, It's very enjoyable and helpful.
-
 - [StackOverflow](https://stackoverflow.com/): A massive resource of questions and answers having to do with coding. If you have a question regarding web development or coding in general, chances are it has already been answered on StackOverflow.
 
 - [Syntax.fm](https://syntax.fm/): The amazing Wes Bos hosts a podcast for web developers. You can also find their episodes on various apps like Spotify etc.
-
-- [The Odin Project](https://www.theodinproject.com/): An online resource which uses other sources to provide a rather complete path for learning web development.
-- [Udacity](https://www.udacity.com/): A website for learning different concepts of computer science.
-
-- [Udemy](https://www.udemy.com/): A website for learning anything that you want to learn. They have many courses in technology, general topics etc...
-
-- [W3Schools](https://www.w3schools.com): A comprehensive learning resource covering HTML, CSS, JavaScript and more. Has interactive tutorials as well as quizzes.
-
-- [OSSU](https://github.com/ossu/computer-science): The OSSU curriculum is a **complete education in computer science** using online materials. It's not merely for career training or professional development. It's for those who want a proper, _well-rounded_ grounding in concepts fundamental to all computing disciplines,and for those who have the discipline, will, and (most importantly!) good habits to obtain this education largely on their own, but with support from a worldwide community of fellow learners.
-
-- [Bento.io](https://bento.io/): A web based platform that offers Free Web Development courses. The curriculum includes HTML, CSS, Javascript, Git, Python and SQL. A great resource for people people who want to learn Web Development starting from Beginner level.
 
 - [Interneting Is Hard](https://internetingishard.com/): A website with nice looking tutorials, learning HTML and CSS the right way. Especialy good tutorials are "Semantic HTML" and "Flexbox".
 

--- a/generalResources.md
+++ b/generalResources.md
@@ -6,25 +6,15 @@
 
 - [CodeSignal](https://www.codesignal.com): Formerly CodeFights, this site has real-world coding questions as well as challenges to keep your skills sharp and help you prepare for interviews.
 
-- [CSS Reference](https://cssreference.io/): An online guide to CSS that features complete descriptions, examples of usage, and illustrated/animated examples of the most popular CSS properties.
-
-- [CSS-Tricks](https://css-tricks.com/): One of the best sites to learn CSS and responsive design.
-
 - [DevHints](https://devhints.io/): A great resource of cheat sheets for a wide range of technologies.
 
 - [First Aid Git](http://firstaidgit.io): A searchable collection of the most frequently asked Git questions.
-
-- [Frontend Masters](https://frontendmasters.com/): A video tutorial website which are workshop based videos. The videos are expert-level workshops for developers that want to learn the secrets to level up their JavaScript and Node.js engineering skills and many more.
-
-- [General Assembly Dash](https://dash.generalassemb.ly/): A set of projects which teach some HTML, CSS, and JavaScript.
 
 - [Scrimba](https://scrimba.com/): A powerful new way of learning code. Play around with the instructors code any time, right in the player.
 
 - [HackerRank](https://www.hackerrank.com/): A place where you can practice coding, prepare for interviews, and get hired.
 
 - [HTMLCheatSheet](https://htmlcheatsheet.com/): A reference sheet for HTML, CSS, and JavaScript that includes helpful code structures (e.g. for setting up a blank page, tables, charts, etc.), and helpful tools such as an RGB color picker, iframe generator, and placeholder text generator.
-
-- [HTML Reference](https://htmlreference.io/): An online guide to HTML that features complete descriptions, and examples of usage for all HTML elements and attributes.
 
 - [Jekyll Cheatsheet](https://learn.cloudcannon.com/jekyll-cheat-sheet/): An excellent resource for learning Jekyll variables and filters.
 

--- a/generalResources.md
+++ b/generalResources.md
@@ -24,6 +24,4 @@
 
 - [StackOverflow](https://stackoverflow.com/): A massive resource of questions and answers having to do with coding. If you have a question regarding web development or coding in general, chances are it has already been answered on StackOverflow.
 
-- [Syntax.fm](https://syntax.fm/): The amazing Wes Bos hosts a podcast for web developers. You can also find their episodes on various apps like Spotify etc.
-
 - [Think Like A Programmer](https://thecodingclassroom.teachable.com/p/think-like-a-programmer): a free online class to help new programmers to build their first projects

--- a/generalResources.md
+++ b/generalResources.md
@@ -26,6 +26,4 @@
 
 - [Syntax.fm](https://syntax.fm/): The amazing Wes Bos hosts a podcast for web developers. You can also find their episodes on various apps like Spotify etc.
 
-- [Interneting Is Hard](https://internetingishard.com/): A website with nice looking tutorials, learning HTML and CSS the right way. Especialy good tutorials are "Semantic HTML" and "Flexbox".
-
 - [Think Like A Programmer](https://thecodingclassroom.teachable.com/p/think-like-a-programmer): a free online class to help new programmers to build their first projects

--- a/moocs.md
+++ b/moocs.md
@@ -4,6 +4,8 @@
 
 ## Computer Science
 
+- [OSSU](https://github.com/ossu/computer-science): The OSSU curriculum is a **complete education in computer science** using online materials. It's not merely for career training or professional development. It's for those who want a proper, _well-rounded_ grounding in concepts fundamental to all computing disciplines,and for those who have the discipline, will, and (most importantly!) good habits to obtain this education largely on their own, but with support from a worldwide community of fellow learners.
+
 ## Web Development
 
 ### Full-Stack

--- a/moocs.md
+++ b/moocs.md
@@ -1,2 +1,11 @@
 # MOOC's (Massive Open Online Courses)
 
+## A Little of Everything
+
+## Computer Science
+
+## Web Development
+
+### Full-Stack
+
+### Front-End

--- a/moocs.md
+++ b/moocs.md
@@ -8,4 +8,16 @@
 
 ### Full-Stack
 
+- [Bento.io](https://bento.io/): A web based platform that offers Free Web Development courses. The curriculum includes HTML, CSS, Javascript, Git, Python and SQL. A great resource for people people who want to learn Web Development starting from Beginner level.
+
+- [Codecademy](https://www.codecademy.com/catalog/subject/web-development): A place to learn and practice web development concepts and languages.
+
+- [Learn Enough](https://www.learnenough.com/courses): A comprehensive guide to providing you with a solid foundation as a developer to become comfortable with all of the tools and technologies you interact with. Created by Michael Hartl – founder of Learn Enough and creator of the Ruby on Rails tutorial – these courses are free to read online and available for purchase as an ebook for your device.
+
+- [SoloLearn](https://www.sololearn.com/): Join the largest community of mobile code learners today. Basically, It's a great app to help you get a basic concept of learning various programming languages easily and those are well structured to learn. It has a very friendly community to join and it's increasing and getting stronger day by day. There is a battle option to compete with others to justify your knowledge. Believe me, It's very enjoyable and helpful.
+
+- [The Odin Project](https://www.theodinproject.com/): An online resource which uses other sources to provide a rather complete path for learning web development.
+
+- [W3Schools](https://www.w3schools.com): A comprehensive learning resource covering HTML, CSS, JavaScript and more. Has interactive tutorials as well as quizzes.
+
 ### Front-End

--- a/moocs.md
+++ b/moocs.md
@@ -43,3 +43,13 @@
 - [W3Schools](https://www.w3schools.com): A comprehensive learning resource covering HTML, CSS, JavaScript and more. Has interactive tutorials as well as quizzes.
 
 ### Front-End
+
+- [CSS Reference](https://cssreference.io/): An online guide to CSS that features complete descriptions, examples of usage, and illustrated/animated examples of the most popular CSS properties.
+
+- [CSS-Tricks](https://css-tricks.com/): One of the best sites to learn CSS and responsive design.
+
+- [Frontend Masters](https://frontendmasters.com/): A video tutorial website which are workshop based videos. The videos are expert-level workshops for developers that want to learn the secrets to level up their JavaScript and Node.js engineering skills and many more.
+
+- [General Assembly Dash](https://dash.generalassemb.ly/): A set of projects which teach some HTML, CSS, and JavaScript.
+
+- [HTML Reference](https://htmlreference.io/): An online guide to HTML that features complete descriptions, and examples of usage for all HTML elements and attributes.

--- a/moocs.md
+++ b/moocs.md
@@ -1,0 +1,2 @@
+# MOOC's (Massive Open Online Courses)
+

--- a/moocs.md
+++ b/moocs.md
@@ -2,6 +2,26 @@
 
 ## A Little of Everything
 
+- [BitDegree](https://www.bitdegree.org/): Website with free/paid online courses about web development, design, graphics, programming etc.
+
+- [Coursera](https://www.coursera.com/): A website for learning from teachers of reputed universities and colleges around the world.
+
+- [edX](https://www.edx.org/): A website with a variety of courses made by schools and such. This does include courses on web development, Python, and other programming languages.
+
+- [egghead](https://egghead.io): A place to learn new web development concepts and languages, both for free and paid.
+
+- [freeCodeCamp.org](https://www.freecodecamp.org): A free site for learning web development. Optionally, you can pledge to donate money to charities while you learn, giving an incentive to keep working. In particular, this site features a number of [JavaScript algorithms](https://learn.freecodecamp.org/coding-interview-prep/algorithms), [data structures](https://learn.freecodecamp.org/coding-interview-prep/data-structures), [take home projects](https://learn.freecodecamp.org/coding-interview-prep/take-home-projects), and [Rosetta Code problems](https://learn.freecodecamp.org/coding-interview-prep/rosetta-code/) as well as a massive list of [Project Euler problems](https://learn.freecodecamp.org/coding-interview-prep/project-euler), all for practice and preparation for technical job interviews.
+
+- [Khan Academy](https://www.khanacademy.org/computing/computer-programming): An online resource for a variety of topics at a multitude of skill levels (from elementary school to postgraduate) that extend beyond computer science. However, their programming courses - which include interactive sandboxes in which learners can tinker with example code - focus on HTML and JavaScript and teach the fundamentals of animation and web design.
+
+- [Microsoft Virtual Academy](https://mva.microsoft.com/): A website with many video courses created by Microsoft. These courses teach a variety of languages, including JavaScript and variants of C.
+
+- [Pluralsight](https://www.pluralsight.com): Pluralsight is the leader in training for serious software developers, IT admins, and creative professionals. With 3,000+ courses and new ones added daily, Pluralsight serves as a career catalyst for customers in more than 150 countries and provides tech-savvy businesses with training on the three key areas they need to thrive.
+
+- [Udacity](https://www.udacity.com/): A website for learning different concepts of computer science.
+
+- [Udemy](https://www.udemy.com/): A website for learning anything that you want to learn. They have many courses in technology, general topics etc...
+
 ## Computer Science
 
 - [OSSU](https://github.com/ossu/computer-science): The OSSU curriculum is a **complete education in computer science** using online materials. It's not merely for career training or professional development. It's for those who want a proper, _well-rounded_ grounding in concepts fundamental to all computing disciplines,and for those who have the discipline, will, and (most importantly!) good habits to obtain this education largely on their own, but with support from a worldwide community of fellow learners.

--- a/moocs.md
+++ b/moocs.md
@@ -8,7 +8,7 @@
 
 - [edX](https://www.edx.org/): A website with a variety of courses made by schools and such. This does include courses on web development, Python, and other programming languages.
 
-- [egghead](https://egghead.io): A place to learn new web development concepts and languages, both for free and paid.
+- [egghead.io](https://egghead.io): A place to learn new web development concepts and languages, both for free and paid.
 
 - [freeCodeCamp.org](https://www.freecodecamp.org): A free site for learning web development. Optionally, you can pledge to donate money to charities while you learn, giving an incentive to keep working. In particular, this site features a number of [JavaScript algorithms](https://learn.freecodecamp.org/coding-interview-prep/algorithms), [data structures](https://learn.freecodecamp.org/coding-interview-prep/data-structures), [take home projects](https://learn.freecodecamp.org/coding-interview-prep/take-home-projects), and [Rosetta Code problems](https://learn.freecodecamp.org/coding-interview-prep/rosetta-code/) as well as a massive list of [Project Euler problems](https://learn.freecodecamp.org/coding-interview-prep/project-euler), all for practice and preparation for technical job interviews.
 


### PR DESCRIPTION
Hello and good morning!

I noticed that the **_generalResources.md_** is this sort of black hole where we put un-categorized resources, and I noticed that most of them were MOOC's (Massive Open Online Course's). So I simply:
- Made a **_moocs.md_** file.
- Connect it to **_README.md_**.
- Added more categories for the MOOC file.
- Transferred the files from **_generalResources.md_** to **_moocs.md_**.

I also removed:

- Deprecated rsrc, [Interneting Is Hard](https://internetingishard.com/), as the domain is no longer accessible to users.
- Repeated [Syntax.fm](https://syntax.fm/) rsrc as it is already used in **_Podcasts.md_**. So I just combined the resource descriptions.

And I made a small title fix for [egghead](https://egghead.io) to become [egghead.io](https://egghead.io)

For more details on the commits, please see commit history.

Thank you very much and have a wonderful day!
