### PR TITLE
feat: Create cheatSheets.md section

### DIFF
--- a/GitandGitHub_Resources/Using_Git_and_GitHub.md
+++ b/GitandGitHub_Resources/Using_Git_and_GitHub.md
@@ -4,9 +4,7 @@
 
 * [Git - The simple guide](https://rogerdudler.github.io/git-guide/): A straight forward, straight to the point git guide that can serve as a quick reference point if you happen to forget something.
 
-* [Git Cheat Sheet](https://education.github.com/git-cheat-sheet-education.pdf): A cheat sheet that features the most important and commonly used Git commands for easy reference.
-
-  * [Git Reference Documentation](https://git-scm.com/docs): A complete listing of Git's features and commands. The documentation is also available as a free ebook titled [Pro Git](https://git-scm.com/book/en/v2).
+* [Git Reference Documentation](https://git-scm.com/docs): A complete listing of Git's features and commands. The documentation is also available as a free ebook titled [Pro Git](https://git-scm.com/book/en/v2).
 
 * [GitHub Guide](https://github.com/antonykidis/GitHub-guide/blob/master/Git%20and%20GitHub.pdf): A pictorial guide for learning Git and Github by [Dmitry.M](https://github.com/antonykidis).
 
@@ -27,8 +25,6 @@
 * [Mastering Markdown](https://guides.github.com/features/mastering-markdown/): Most web pages (especially the README) on GitHub are written using the Markdown HTML-preprocessor language.
 
   * Another useful resource for Markdown is the [Daring Fireball](https://daringfireball.net/projects/markdown/syntax) website.
-
-* [Markdown Cheat Sheet](https://guides.github.com/pdfs/markdown-cheatsheet-online.pdf): Everything you need to know about Markdown laid out in a PDF format.
 
 * [Markdown Emoji's](https://github.com/StuartDaniells/Markdown_Emoji-s_List): One stop for all your favorite Emoji's using Markdown.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 * [**Articles**](DevelopmentArticles.md): General articles page on web development.
 
+* [**Cheat Sheets**](cheatSheets.md): For those looking for the quick-and-dirty of how to do things, or if you simply forgot something, look no further!
+
 * [**General Resources for Learning Web Development**](generalResources.md): A page with mostly free resources for learning web development and coding in general.
 
 * [**Git and Github**](GitandGitHub_Resources/Using_Git_and_GitHub.md): Resources page on using Git and GitHub.

--- a/cheatSheets.md
+++ b/cheatSheets.md
@@ -1,0 +1,2 @@
+# Cheat Sheets
+

--- a/cheatSheets.md
+++ b/cheatSheets.md
@@ -2,6 +2,10 @@
 
 - [DevHints](https://devhints.io/): A great resource of cheat sheets for a wide range of technologies.
 
+- [Git Cheat Sheet](https://education.github.com/git-cheat-sheet-education.pdf): A cheat sheet that features the most important and commonly used Git commands for easy reference.
+
 - [HTMLCheatSheet](https://htmlcheatsheet.com/): A reference sheet for HTML, CSS, and JavaScript that includes helpful code structures (e.g. for setting up a blank page, tables, charts, etc.), and helpful tools such as an RGB color picker, iframe generator, and placeholder text generator.
 
 - [Jekyll Cheatsheet](https://learn.cloudcannon.com/jekyll-cheat-sheet/): An excellent resource for learning Jekyll variables and filters.
+
+- [Markdown Cheat Sheet](https://guides.github.com/pdfs/markdown-cheatsheet-online.pdf): Everything you need to know about Markdown laid out in a PDF format.

--- a/cheatSheets.md
+++ b/cheatSheets.md
@@ -1,2 +1,7 @@
 # Cheat Sheets
 
+- [DevHints](https://devhints.io/): A great resource of cheat sheets for a wide range of technologies.
+
+- [HTMLCheatSheet](https://htmlcheatsheet.com/): A reference sheet for HTML, CSS, and JavaScript that includes helpful code structures (e.g. for setting up a blank page, tables, charts, etc.), and helpful tools such as an RGB color picker, iframe generator, and placeholder text generator.
+
+- [Jekyll Cheatsheet](https://learn.cloudcannon.com/jekyll-cheat-sheet/): An excellent resource for learning Jekyll variables and filters.

--- a/generalResources.md
+++ b/generalResources.md
@@ -6,17 +6,11 @@
 
 - [CodeSignal](https://www.codesignal.com): Formerly CodeFights, this site has real-world coding questions as well as challenges to keep your skills sharp and help you prepare for interviews.
 
-- [DevHints](https://devhints.io/): A great resource of cheat sheets for a wide range of technologies.
-
 - [First Aid Git](http://firstaidgit.io): A searchable collection of the most frequently asked Git questions.
 
 - [Scrimba](https://scrimba.com/): A powerful new way of learning code. Play around with the instructors code any time, right in the player.
 
 - [HackerRank](https://www.hackerrank.com/): A place where you can practice coding, prepare for interviews, and get hired.
-
-- [HTMLCheatSheet](https://htmlcheatsheet.com/): A reference sheet for HTML, CSS, and JavaScript that includes helpful code structures (e.g. for setting up a blank page, tables, charts, etc.), and helpful tools such as an RGB color picker, iframe generator, and placeholder text generator.
-
-- [Jekyll Cheatsheet](https://learn.cloudcannon.com/jekyll-cheat-sheet/): An excellent resource for learning Jekyll variables and filters.
 
 - [MDN Web Docs](https://developer.mozilla.org/en-US/): A resource for developers, maintained by the community of developers and technical writers and hosting many documents on a wide variety of subjects, such as: HTML, CSS, HTTP, JavaScript, Web APIs, Web components, Graphics, Audio, video and multimedia, MathML.
 


### PR DESCRIPTION
Good morning everyone!

I noticed that several cheat sheet resources were scattered all over the place! So I thought it would be nice to group them all together in one place, aptly named **Cheat Sheets** in the **_cheatSheets.md_** file.

I linked up the new file in the **_README.md_**.

I then moved 3 resources from **_generalResources.md_**, and 2 from **_usingGitAndGithub.md_** to **_cheatSheets.md_**

For more detailed information, please refer to the git commit history.

Thank you and have a nice day!