### PR TITLE
Fix broken link to 7h tutorial

### DIFF
--- a/JavaScript.md
+++ b/JavaScript.md
@@ -19,7 +19,7 @@
 
 - [JavaScript For Cats](http://jsforcats.com/): An introduction for new programmers.
 
-- [JavaScript Fundamentals for Absolute Beginners](https://www.youtube.com/watch?v=YMvzfQSI6pQ&t=5032s): A 7 hour long video with detailed explanations to give a strong foundation in JavaScript fundamentals. Taught by Bob Tabor, one of the most effective web development teachers.
+- [JavaScript Fundamentals for Absolute Beginners](https://www.youtube.com/watch?v=ei2HLyHwt-k): A 7 hour long video with detailed explanations to give a strong foundation in JavaScript fundamentals. Taught by Bob Tabor, one of the most effective web development teachers.
 
 - [JavaScript Jabber](https://devchat.tv/js-jabber/): A weekly podcast discussing the superb language JavaScript.
 


### PR DESCRIPTION
Link to "JavaScript Fundamentals for Absolute Beginners" was broken -> Replaced it with an updated link