### PR TITLE
Update link to newer version of article about Learn to code in 2020

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -121,3 +121,4 @@ This is a list showing the GitHub usernames of all who have contributed to this 
 - [@Yoavbenzvi](https://github.com/Yoavbenzvi)
 - [@darnvisages](https://github.com/darnvisages)
 - [@Blusoup](https://github.com/Blusoup)
+- [@wroblewskim95](https://github.com/wroblewskim95)

--- a/DevelopmentArticles.md
+++ b/DevelopmentArticles.md
@@ -1,24 +1,25 @@
 **[Back](/README.md/)**
+
 # ARTICLES ABOUT DEVELOPMENT
 
-* [**Learn to code in 2018, get hired, and have fun along the way**](https://hackernoon.com/learn-to-code-in-2018-get-hired-and-have-fun-along-the-way-b338247eed6a): Article by Andrei Neagoie that got many of us into this class. If you haven't read it, it's worth a read and has a few more items of info that are not necessarily in the lessons.
+- [**Learn to code in 2020, get hired, and have fun along the way**](https://zerotomastery.io/blog/learn-to-code-in-2020-get-hired-and-have-fun-along-the-way/): Article by Andrei Neagoie that got many of us into this class. If you haven't read it, it's worth a read and has a few more items of info that are not necessarily in the lessons.
 
-* [**Tools I wish I had known about when I started coding**](https://medium.freecodecamp.org/tools-i-wish-i-had-known-about-when-i-started-coding-57849efd9248): Article by Mario Hoyos. Chrome extensions listed are on the tools page.
+- [**Tools I wish I had known about when I started coding**](https://medium.freecodecamp.org/tools-i-wish-i-had-known-about-when-i-started-coding-57849efd9248): Article by Mario Hoyos. Chrome extensions listed are on the tools page.
 
-* [**Tools I wish I had known about when I started coding: Revisited**](https://medium.freecodecamp.org/tools-i-wish-i-had-known-about-when-i-started-coding-revisited-ffb715ffd23f): Article by Mario Hoyos. With more and different info.
+- [**Tools I wish I had known about when I started coding: Revisited**](https://medium.freecodecamp.org/tools-i-wish-i-had-known-about-when-i-started-coding-revisited-ffb715ffd23f): Article by Mario Hoyos. With more and different info.
 
-* [**front-end-guide**](https://github.com/grab/front-end-guide): An extended article/GitHub repo that addresses what a modern web developer should study and be aware of. This is written from the perspective of a developer informing new employees as to what are the current practices at his company, [Grab](https://www.grab.com/sg/), a ride-sharing service.
+- [**front-end-guide**](https://github.com/grab/front-end-guide): An extended article/GitHub repo that addresses what a modern web developer should study and be aware of. This is written from the perspective of a developer informing new employees as to what are the current practices at his company, [Grab](https://www.grab.com/sg/), a ride-sharing service.
 
-* [**Front End Web Development Setup**](https://www.taniarascia.com/my-front-end-web-development-setup/): An informative article on how to put together a front-end development environment.
+- [**Front End Web Development Setup**](https://www.taniarascia.com/my-front-end-web-development-setup/): An informative article on how to put together a front-end development environment.
 
-* [**Modern Development Environment for Windows**](https://char.gd/blog/2017/how-to-set-up-the-perfect-modern-dev-environment-on-windows): Setting up a windows computer for front-end development.
+- [**Modern Development Environment for Windows**](https://char.gd/blog/2017/how-to-set-up-the-perfect-modern-dev-environment-on-windows): Setting up a windows computer for front-end development.
 
-* [**React vs Vue.JS: Which Front-end Framework to Choose in 2018**](https://expertise.jetruby.com/react-vs-vue-js-which-front-end-framework-to-choose-in-2018-2a62a1fe76f9) : In this article, we’ll briefly consider the status quo in the world of modern JavaScript frameworks, comparing React and Vue.JS.
+- [**React vs Vue.JS: Which Front-end Framework to Choose in 2018**](https://expertise.jetruby.com/react-vs-vue-js-which-front-end-framework-to-choose-in-2018-2a62a1fe76f9) : In this article, we’ll briefly consider the status quo in the world of modern JavaScript frameworks, comparing React and Vue.JS.
 
-* [**Productivity: How I am so productive - Kent C. Dodds**](https://blog.kentcdodds.com/how-i-am-so-productive-fb86eb583b0d): In this article, Kent sharing his daily activity that makes him so productive.
+- [**Productivity: How I am so productive - Kent C. Dodds**](https://blog.kentcdodds.com/how-i-am-so-productive-fb86eb583b0d): In this article, Kent sharing his daily activity that makes him so productive.
 
-* [**The Cost of Javascript - Addy Osmani**](https://medium.com/@addyosmani/the-cost-of-javascript-in-2018-7d8950fbb5d4): Article about being mindful of what and how we use javascript in our applications.
+- [**The Cost of Javascript - Addy Osmani**](https://medium.com/@addyosmani/the-cost-of-javascript-in-2018-7d8950fbb5d4): Article about being mindful of what and how we use javascript in our applications.
 
-* [**How The Web Works - Maximilian Schwarzmüller**](https://www.academind.com/learn/web-dev/how-the-web-works/): An introduction on how the web actually works.
+- [**How The Web Works - Maximilian Schwarzmüller**](https://www.academind.com/learn/web-dev/how-the-web-works/): An introduction on how the web actually works.
 
-* [**Static vs Dynamic vs SPA - Maximilian Schwarzmüller**](https://www.academind.com/learn/web-dev/dynamic-vs-static-vs-spa/): In this article the author explains different techniques on how to build modern web pages and the pros & cons of each.
+- [**Static vs Dynamic vs SPA - Maximilian Schwarzmüller**](https://www.academind.com/learn/web-dev/dynamic-vs-static-vs-spa/): In this article the author explains different techniques on how to build modern web pages and the pros & cons of each.


### PR DESCRIPTION
I updated the link to a newer version of the article Learn to code in 2020, because it was an earlier version for the article from 2018, so it was out of date, and this link did not work and could not find the page with this article