### PR TITLE
Added new category: CSS Resources

### DIFF
--- a/CSSResources.md
+++ b/CSSResources.md
@@ -1,0 +1,29 @@
+**[Back](/README.md/)**
+
+# CSS Resources
+
+## Resources for Learning CSS
+
+- [CSS Reference](https://cssreference.io): A visual representation, and demonstration of all native CSS3 rules and how they work, with clear documentation and examples.
+
+- [CSS Visual Dictionary](http://www.javascriptgrammar.com/?v=bio): CSS Visual Dictionary is a beginner-friendly book that takes a practical approach towards introducing web designers and developers to the basic concepts in CSS. Follow the instructions in the link above to get your copy!
+
+- [CSS Zen Garden](http://www.csszengarden.com/): A demonstration of what can be accomplished through CSS-based design. Style sheets contributed by graphic designers from around the world are used to change the visual presentation of a single HTML file, producing hundreds of different designs.
+
+- [CSS-Tricks](https://css-tricks.com/): One of the best sites to learn CSS and responsive design.
+
+## CSS Games
+
+- [CSS diner](https://flukeout.github.io/): A fun in-browser game to help you learn and practice CSS selectors.
+
+- [Flexbox Defense](http://www.flexboxdefense.com/): Tower Defense with a twist: all towers must be positioned with CSS flexbox.
+
+- [Flexbox Froggy](http://flexboxfroggy.com/): A fun in-browser game to help teach the powerful, complex CSS flexbox layout method.
+
+- [Grid Garden](https://cssgridgarden.com/): A fun in-browser game to help teach the powerful, complex CSS grid layout method.
+
+## CSS Tools
+
+- [Clippy](https://bennettfeely.com/clippy/): A tool for creating CSS clip paths of various shapes.
+
+- [Cubic-Bezier](https://cubic-bezier.com/): A tool for generating bezier curves for CSS transitions and animations.

--- a/README.md
+++ b/README.md
@@ -1,36 +1,39 @@
 # Useful Resources for Developers
-A list of student collated resources deemed to be useful for every developer and catergorised. Andrei has a hand picked list of his favourite resources which you can find [here](https://zerotomastery.io/resources?utm_source=github&utm_medium=resources)
+
+A list of student collated resources deemed to be useful for every developer and catergorised. Andrei has a hand picked list of his favourite resources which you can find [here](https://zerotomastery.io/resources?utm_source=github&utm_medium=resources).
 
 ## Table of Contents
 
-* [**Articles**](DevelopmentArticles.md): General articles page on web development.
+- [**Articles**](DevelopmentArticles.md): General articles page on web development.
 
-* [**Cheat Sheets**](cheatSheets.md): For those looking for the quick-and-dirty of how to do things, or if you simply forgot something, look no further!
+- [**Cheat Sheets**](cheatSheets.md): For those looking for the quick-and-dirty of how to do things, or if you simply forgot something, look no further!
 
-* [**General Resources for Learning Web Development**](generalResources.md): A page with mostly free resources for learning web development and coding in general.
+- [**CSS Resources**](CSSResources.md): A list of resources for learning CSS.
 
-* [**Git and Github**](Using_Git_and_GitHub.md): Resources page on using Git and GitHub.
+- [**General Resources for Learning Web Development**](generalResources.md): A page with mostly free resources for learning web development and coding in general.
 
-* [**Interviewing for Coding Jobs**](HowtoInterviewforCodeJobs.md): A page of resources about preparing for the job market.
+- [**Git and Github**](Using_Git_and_GitHub.md): Resources page on using Git and GitHub.
 
-* [**JavaScript Resources**](JavaScript.md): A list of resources for learning JavaScript.
+- [**Interviewing for Coding Jobs**](HowtoInterviewforCodeJobs.md): A page of resources about preparing for the job market.
 
-* [**MOOCs (Massive Open Online Courses)**](moocs.md): Showcasing effective online courses that covers areas such as Full-Stack development, Front-End development, Computer Science, or even a little of everything!
+- [**JavaScript Resources**](JavaScript.md): A list of resources for learning JavaScript.
 
-* [**Podcasts**](Podcasts.md): A range of podcasts covering topics like coding, design, accessibility, JavaScript, and Mindset/Self-Development.
+- [**MOOCs (Massive Open Online Courses)**](moocs.md): Showcasing effective online courses that covers areas such as Full-Stack development, Front-End development, Computer Science, or even a little of everything!
 
-* [**Programming Books**](Programming_Books.md): Featuring a list of insightful programming books, both free and paid versions.
+- [**Podcasts**](Podcasts.md): A range of podcasts covering topics like coding, design, accessibility, JavaScript, and Mindset/Self-Development.
 
-* [**Python Resources**](Python.md): A list of resources for learning Python.
+- [**Programming Books**](Programming_Books.md): Featuring a list of insightful programming books, both free and paid versions.
 
-* [**Web Design Resources**](WebDesignResources.md): A page of resources for web design.
+- [**Python Resources**](Python.md): A list of resources for learning Python.
 
-* [**Web Development Tools**](WebDevTools.md): A page listing a number of free web development tools.
+- [**Web Design Resources**](WebDesignResources.md): A page of resources for web design.
 
-* [**YouTube Channels**](YouTubeChannels.md): A list of YouTube channels for learning all about programming, covering topics as broad as web development, design, history, hacking, and Computer Science (CS).
+- [**Web Development Tools**](WebDevTools.md): A page listing a number of free web development tools.
+
+- [**YouTube Channels**](YouTubeChannels.md): A list of YouTube channels for learning all about programming, covering topics as broad as web development, design, history, hacking, and Computer Science (CS).
 
 ## Contributing
 
-* You are always welcome to contribute to this project, kindly visit our [**Contributors' Guide**](https://github.com/zero-to-mastery/resources/blob/master/CONTRIBUTING.md) before opening a pull request
+- You are always welcome to contribute to this project, kindly visit our [**Contributors' Guide**](https://github.com/zero-to-mastery/resources/blob/master/CONTRIBUTING.md) before opening a pull request
 
-* [**List of Contributors**](CONTRIBUTORS.md): A page showing the GitHub usernames of all who have contributed to this open-source project! Make sure to add yourself and submit a pull request if you've contributed.
+- [**List of Contributors**](CONTRIBUTORS.md): A page showing the GitHub usernames of all who have contributed to this open-source project! Make sure to add yourself and submit a pull request if you've contributed.

--- a/WebDesignResources.md
+++ b/WebDesignResources.md
@@ -10,27 +10,11 @@
 
 - [Can I use...](https://caniuse.com/): Browser support tables for modern web technologies.
 
-- [CSS diner](https://flukeout.github.io/): A fun in-browser game to help you learn and practice CSS selectors.
-
-- [CSS Zen Garden](http://www.csszengarden.com/): A demonstration of what can be accomplished through CSS-based design. Style sheets contributed by graphic designers from around the world are used to change the visual presentation of a single HTML file, producing hundreds of different designs.
-
-- [CSS Reference](https://cssreference.io): A visual representation, and demonstration of all native CSS3 rules and how they work, with clear documentation and examples.
-
-- [CSS Visual Dictionary](http://www.javascriptgrammar.com/?v=bio): CSS Visual Dictionary is a beginner-friendly book that takes a practical approach towards introducing web designers and developers to the basic concepts in CSS. Follow the instructions in the link above to get your copy!
-
-- [CSS-Tricks](https://css-tricks.com/): One of the best sites to learn CSS and responsive design.
-
 - [DesignAcademy.io](https://designacademy.io/): Laura Elizabeth made this fantastic, easy-to-understand design fundamentals course for developers to learn within 6 weeks, after spending years struggling to grasp and implement design principles. She offers both a paid course as well as free resources in the form of blog posts and snippets of her course.
 
 - [devdocs](https://devdocs.io/): DevDocs combines multiple API documentations for a fast, organized and searchable interface for developers.
 
-- [Flexbox Defense](http://www.flexboxdefense.com/): Tower Defense with a twist: all towers must be positioned with CSS flexbox.
-
-- [Flexbox Froggy](http://flexboxfroggy.com/): A fun in-browser game to help teach the powerful, complex CSS flexbox layout method.
-
 - [Frontend Mentor](https://www.frontendmentor.io/): A platform where you can practice your web design skills using HTML, CSS & JS and design modern websites.
-
-- [Grid Garden](https://cssgridgarden.com/): A fun in-browser game to help teach the powerful, complex CSS grid layout method.
 
 - [Inside Design](https://www.invisionapp.com/inside-design/): Invision, one of the most prolific and wildly successful design company in the world – whose products/workflow are used by companies like Airbnb, Amazon, HBO, Netflix, Slack, Starbucks and Uber – offers free design resources and perspectives in their blog, **Inside Design**. They are also hiring for those interested.
 


### PR DESCRIPTION
Added CSS Resources category as mentioned here: https://github.com/zero-to-mastery/resources/issues/384. Moved some links from Web Design Resources into new CSS Resources, and added a couple new links to CSS Resources. @SamirJouni 