### PR TITLE
Revert "Jallah's Update"

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -146,4 +146,3 @@ This is a list showing the GitHub usernames of all who have contributed to this 
 - [@rohithv07](https://github.com/Rohithv07)
 - [@JoconDC](https://github.com/JoconDC)
 - [@TheGalekxy](https://github.com/TheGalekxy)
-- [@Sumbo-1](https://github.com/Sumbo-1)


### PR DESCRIPTION
Reverts zero-to-mastery/resources#425

Reasons see [here](https://github.com/zero-to-mastery/resources/pull/425#issuecomment-653591712).