### PR TITLE
Updated travis settings for 2020 configurations.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+os: linux
+arch: arm64
+dist: bionic
 language: ruby
 rvm:
   - 2.6.3
@@ -20,8 +23,6 @@ addons:
   apt:
     packages:
     - libcurl4-openssl-dev
-
-sudo: false
 
 cache: bundler
 


### PR DESCRIPTION
Just cleaned up and updated the travis configuration file to match their new requirements. 

### Here are the things I did:

Removed SUDO as it's irrelvant.
Specified OS and Architecture.
Cleanup removed parameters.