### PR TITLE
Changed the Alogirthms Youtube link to point to the videos' playlist

### DIFF
--- a/AlgorithmsDataStructures.md
+++ b/AlgorithmsDataStructures.md
@@ -4,7 +4,7 @@
 
 ## Videos
 
-- [Abdul Bari: YouTubeChannel for Algorithms](https://www.youtube.com/channel/UCZCFT11CWBi3MHNlGf019nw)
+- [Abdul Bari: YouTubeChannel for Algorithms](https://www.youtube.com/watch?v=0IAPZzGSbME&list=PLDN4rrl48XKpZkf03iYFl-O29szjTrs_O&index=2&t=0s)
 
 ## GitBook
 - [Data Structures in C](https://nitinranganath.gitbook.io/data-structures/)


### PR DESCRIPTION
I have changed the youtube link under Algorithms and Datastructures to point to the YT link of the playlist instead of Abdul Basir's channel. This could make the student reach the resource easier.