### PR TITLE
Cleanp, add new categories to index file

### DIFF
--- a/Coding Websites.md
+++ b/Coding Websites.md
@@ -1,8 +1,0 @@
-| Website    | Link |
-| ----------- | ----------- |
-| Hackerrank   | [Website](https://www.hackerrank.com/)      |
-| HackerEarth   | [Website](https://www.hackerearth.com/)        |
-| Codeforces   | [Website](https://codeforces.com/)      |
-|Codechef  | [Website](https://www.codechef.com/)        |
-| Interviewbit   | [Website](https://www.interviewbit.com/)      |
-|GeeksforGeeks | [Website](https://www.geeksforgeeks.org/)        |

--- a/Popular blogs for Machine Learning.txt
+++ b/Popular blogs for Machine Learning.txt
@@ -1,9 +1,0 @@
-To stay updated with machine learning, AI, Data science, deep learning and python trends...
-1. Towards Data science
-https://towardsdatascience.com/
-
-2. Machine Learning mastery blogs
-https://machinelearningmastery.com/blog/
-
-3. Analytics Vidhya blogs
-https://www.analyticsvidhya.com/blog/

--- a/README.md
+++ b/README.md
@@ -8,9 +8,13 @@ A list of student-collated resources deemed to be useful for every developer and
 
 - [**Angular Resources**](Angular.md): A list of resources for learning Angular.
 
+- [**Arduino**](Arduino.md): A list of resources for the Arduino micro-controller.
+
 - [**Articles**](DevelopmentArticles.md): General articles page on web development.
 
 - [**Cheat Sheets**](cheatSheets.md): For those looking for the quick-and-dirty of how to do things, or if you simply forgot something, look no further!
+
+- [**Cloud**](Cloud.md): Cloud Learning Resources to kickstart your career.
 
 - [**CSS Resources**](CSSResources.md): A list of resources for learning CSS.
 
@@ -25,6 +29,8 @@ A list of student-collated resources deemed to be useful for every developer and
 - [**MOOCs (Massive Open Online Courses)**](moocs.md): Showcasing effective online courses that covers areas such as Full-Stack development, Front-End development, Computer Science, or even a little of everything!
 
 - [**Mobile App Development**](MobileAppDevelopment.md): A curated list of useful resources for mobile app development (for Android, iOS, Windows, or any other mobile system
+
+- [**Practice Resources**](PracticeResources.md): A list of exercises and gamified resources for web development.
 
 - [**Podcasts**](Podcasts.md): A range of podcasts covering topics like coding, design, accessibility, JavaScript, and Mindset/Self-Development.
 


### PR DESCRIPTION
This commit removes a `.txt` file taht we cannot render and which adds a category that's vague. Details see PR #512.
I've also added links to the newly added categories (Cloud, Arduino, etc.)