### PR TITLE
Fix failing Travis CI, fix link, sort resources

### DIFF
--- a/GameDev.md
+++ b/GameDev.md
@@ -49,7 +49,7 @@
 ### Resources for Beginners:
 - [Mixamo](https://www.mixamo.com/#/): For Rigging your 3D models and animating them by selecting the templates in it.
 - [Bosca Ceoil](https://boscaceoil.net/): For making SFX and music for your games.
-- [GIMP](gimp.org): For making 2D art.
+- [GIMP](https://gimp.org): For making 2D art.
 - [Blender](https://www.blender.org/): For 3D art, this is not only used by beginners but also for the AAA level games in the industry.
 
 

--- a/README.md
+++ b/README.md
@@ -4,21 +4,23 @@ A list of student-collated resources deemed to be useful for every developer and
 
 ## Table of Contents
 
+- [**API**](API.md): A list of resources for learning how to use APIs.
+
 - [**Algorithms & Data Structures**](AlgorithmsDataStructures.md): Resources for tackling algorithms.
 
 - [**Angular Resources**](Angular.md): A list of resources for learning Angular.
-
-- [**API**](API.md): A list of resources for learning how to use APIs.
 
 - [**Arduino**](Arduino.md): A list of resources for the Arduino micro-controller.
 
 - [**Articles**](DevelopmentArticles.md): General articles page on web development.
 
+- [**CSS Resources**](CSSResources.md): A list of resources for learning CSS.
+
 - [**Cheat Sheets**](cheatSheets.md): For those looking for the quick-and-dirty of how to do things, or if you simply forgot something, look no further!
 
 - [**Cloud**](Cloud.md): Cloud Learning Resources to kickstart your career.
 
-- [**CSS Resources**](CSSResources.md): A list of resources for learning CSS.
+- [**Game Development Resources**](GameDev.md): A page which lists out the resources which helps you go from zero to mastery in game development.
 
 - [**General Resources for Learning Web Development**](generalResources.md): A page with mostly free resources for learning web development and coding in general.
 
@@ -32,15 +34,15 @@ A list of student-collated resources deemed to be useful for every developer and
 
 - [**Mobile App Development**](MobileAppDevelopment.md): A curated list of useful resources for mobile app development (for Android, iOS, Windows, or any other mobile system
 
-- [**Practice Resources**](PracticeResources.md): A list of exercises and gamified resources for web development.
-
 - [**Podcasts**](Podcasts.md): A range of podcasts covering topics like coding, design, accessibility, JavaScript, and Mindset/Self-Development.
 
-- [**Raspberry Pi**](RaspberryPi.md): Resources for the Raspberry Pi.
+- [**Practice Resources**](PracticeResources.md): A list of exercises and gamified resources for web development.
 
 - [**Programming Books**](Programming_Books.md): Featuring a list of insightful programming books, both free and paid versions.
 
 - [**Python Resources**](Python.md): A list of resources for learning Python.
+
+- [**Raspberry Pi**](RaspberryPi.md): Resources for the Raspberry Pi.
 
 - [**Search Engine Optimization**](SearchEngineOptimization.md): A list of resources for learning Search Engine Optimization(SEO).
 
@@ -50,14 +52,12 @@ A list of student-collated resources deemed to be useful for every developer and
 
 - [**Web Development Tools**](WebDevTools.md): A page listing a number of free web development tools.
 
-- [**Game Development Resources**](GameDev.md): A page which lists out the resources which helps you go from zero to mastery in game development.
-
 - [**YouTube Channels**](YouTubeChannels.md): A list of YouTube channels for learning all about programming, covering topics as broad as web development, design, history, hacking, and Computer Science (CS).
-
 
 ## Contributing
 
 - You are always welcome to contribute to this project, kindly visit our [**Contributors' Guide**](https://github.com/zero-to-mastery/resources/blob/master/CONTRIBUTING.md) before opening a pull request.
+
 - First time contributing to open source? Awesome! Read more about the process in [**Contributing to GitHub**](https://github.com/zero-to-mastery/resources/blob/master/Contributing_to_GitHub.md).
 
 - [**List of Contributors**](CONTRIBUTORS.md): A page showing the GitHub usernames of all who have contributed to this open-source project! Make sure to add yourself and submit a pull request if you've contributed.


### PR DESCRIPTION
This commit fixes the broken link in Game Dev (gimp), that made the Travis CI build fail. I've also sorted the resources in the README file alphabetically.