### PR TITLE
Fix Broken Link in Javascript.md

### DIFF
--- a/JavaScript.md
+++ b/JavaScript.md
@@ -104,4 +104,4 @@
 
 - [Babel](https://babeljs.io): Babel is a JavaScript compiler. Used in almost all JavaScripts projects today.
 
-- [Rome](https://romefrontend.dev): A new frontend toolchain designed to replace Babel, ESLint, webpack, Prettier, Jest, and others. From the creator of Babel and Yarn, Sebastian McKenzie.
+- [Rome](https://rome.tools): A new frontend toolchain designed to replace Babel, ESLint, webpack, Prettier, Jest, and others. From the creator of Babel and Yarn, Sebastian McKenzie.


### PR DESCRIPTION
Original link: https://romefrontend.dev was broken, the new correct link is https://rome.tools