### PR TITLE
edit url for coding bat python

### DIFF
--- a/PracticeResources.md
+++ b/PracticeResources.md
@@ -22,7 +22,7 @@
 
 # Resources for Practicing Python Development
 
-- [Coding Bat (Python)](https://codingbat.com/python/): Practice problems exploring the basics of Python (Beginner, Intermediate)
+- [Coding Bat (Python)](https://codingbat.com/python): Practice problems exploring the basics of Python (Beginner, Intermediate)
 
 - [Exercism](https://exercism.io/): Hundreds of practice problems in Python and many other languages (Beginner, Intermediate, Advanced)
  


### PR DESCRIPTION
edited url for "coding bat python" since its not working due to slash at end.
old url: [https://codingbat.com/python/](https://codingbat.com/python/) shows **HTTP Status 404 -**
corrected url: [https://codingbat.com/python](https://codingbat.com/python) 