### PR TITLE
Added CompSciLib to General Resources

### DIFF
--- a/generalResources.md
+++ b/generalResources.md
@@ -50,3 +50,5 @@
 * [GitHub Student Developer Pack](https://education.github.com/pack): Resources from a wide range of well known organisations provided for free or at a discount through the GitHub Student Developer Pack, very useful for those in university or recently graduated. STUDENT CARD AND STUDENT EMAIL REQUIRED.
 
 * [roadmap.sh](https://roadmap.sh): Displays dedicated roadmaps for a specific field or technology including Front End, Back End, Full Stack, React, Java etc.
+
+* [**CompSciLib**](https://www.compscilib.com/): A free site for learning and practicing Computer Science theory topics in courses such as Computer Organization, Discrete Math, Networking, etc. Think Khan Academy, but for Computer Science.


### PR DESCRIPTION
## Resource name and link

<!-- Add the resource name and the link in this section -->
[CompSciLib](https://www.compscilib.com)

<!-- eg. [Resource Name](link) -> Use this format(including the square and round brackets) to add name link of resource -->

## Short description
A free site for learning and practicing Computer Science theory topics in courses such as Computer Organization, Discrete Math, Networking, etc. Think Khan Academy, but for Computer Science.

<!-- Include a short description of the resource in this section -->

## Why do you think this is a good resource?
While most products cover programming and do a great job of it, there are minimal products that touch on Computer Science theory in an interactive way. CompSciLib provides a solution to that issue.

<!-- Add a reason why the resource can be helpful to the community -->
It's helpful to college students taking the classes the platform provides, in addition to the discord community.

## GitHub repository (optional)
N/A
<!-- Add the link to the GitHub repository of the resource (if any) -->