### PR TITLE
Add apollo client chrome extension

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -251,5 +251,6 @@ This is a list showing the GitHub usernames of all who have contributed to this 
 - [@rawatdev](https://github.com/rawatdev)
 - [@amarchiori](https://github.com/amarchiori)
 - [@JUNKJACKZACK](https://github.com/JUNKJACKZACK)
+- [@alejosilvalau](https://github.com/alejosilvalau)
 - [@justin2172021](https://github.com/justin2172021)
 - [@rhinoxD](https://github.com/rhinoxD)

--- a/WebDevTools.md
+++ b/WebDevTools.md
@@ -116,6 +116,8 @@ Things to look for if your editor has implementations for them. They will make y
 
 - [WhatFont](https://chrome.google.com/webstore/detail/whatfont/jabopobgcpjmedljpbcaablpmlmfcogm): Instantly find out what font is being used with a click. No Developer Mode required.
 
+- [Apollo Client Devtools](https://chrome.google.com/webstore/detail/apollo-client-devtools/jdkknkkbebbapilgoeccciglkfbmbnfm): GraphQL debugging tools for Apollo Client.
+
 ---
 
 ## CSS Tools


### PR DESCRIPTION
## Resource name and link

<!-- Add the resource name and the link in this section -->

[Apollo Client Devtools](https://chrome.google.com/webstore/detail/apollo-client-devtools/jdkknkkbebbapilgoeccciglkfbmbnfm)

<!-- eg. [Resource Name](link) -> Use this format(including the square and round brackets) to add name link of resource -->

## Short description

<!-- Include a short description of the resource in this section -->

GraphQL debugging tools for Apollo Client.

## Why do you think this is a good resource?

<!-- Add a reason why the resource can be helpful to the community -->

Apollo Client Devtools is a Chrome extension for the open-source GraphQL client, Apollo Client. This extension has 4 main features:

1. A built-in version of the Apollo Studio Explorer that allows you to make queries against your GraphQL server using your app's network interface directly (no configuration necessary).

2. A query watcher that shows you which queries are being watched by the current page, when those queries are loading, and what variables those queries are using.

3. A mutation inspector that displays the mutations made to your Apollo Client application data.

4. A cache inspector that displays your Apollo Client cache data. You can explore the cache through a tree-like interface, and search for specific field keys and values.

## GitHub repository (optional)

<!-- Add the link to the GitHub repository of the resource (if any) -->
https://github.com/apollographql/apollo-client-devtools
