### PR TITLE
Create new podcast category on product management and design and add the product talk podcast

### DIFF
--- a/Podcasts.md
+++ b/Podcasts.md
@@ -38,13 +38,13 @@
 - [Self-Taught or Not](https://www.selftaughtornot.com/): A podcast covering the do's and don'ts of software development, hosted by two software developers; one self-taught, and one not. Topics include advice for developers, technologies, interviews, and more.
 - [Ladybug Podcast](https://www.ladybug.dev/): This podcast co-hosted by 3 ladies who wanted to add their voices to the space and share their experiences and advice. They have great discussions around how to start coding, the hot technologies right now, how to get your first developer job, and more!
 - [The Stack Overflow Podcast](https://stackoverflow.blog/podcast/): The Stack Overflow podcast is a weekly conversation about working in software development, learning to code, and the art and culture of computer programming. Hosted by Sara Chipps, Paul Ford, and Ben Popper, the series will feature questions from our community, interviews with fascinating guests, and hot takes on what’s happening in tech.
-- [HTML All The Things](https://www.htmlallthethings.com/podcast): Join hosts Matt Lawrence and Mike Karan as they dive into the world of web development and design. In this show, they discuss running a small business, making websites, and web apps for customers from all over the industry.  Matt and Mike also take a deep dive into things like their latest projects, their business strategies, and much more! 
+- [HTML All The Things](https://www.htmlallthethings.com/podcast): Join hosts Matt Lawrence and Mike Karan as they dive into the world of web development and design. In this show, they discuss running a small business, making websites, and web apps for customers from all over the industry. Matt and Mike also take a deep dive into things like their latest projects, their business strategies, and much more!
 
 ## Cloud
 
 - [Google Cloud Platform Podcast](https://www.gcppodcast.com/): The Google Cloud Platform Podcast, discussing everything on Google Cloud Platform from App Engine to Big Query. Coming to you every week.
-- [Kubernetes Podcast from Google](https://kubernetespodcast.com/): A weekly podcast focused on what's happening in the Kubernetes community covering Kubernetes, cloud-native applications, and other developments in the Kubernetes community. Co-hosts Adam Glick and Craig Box. 
-- [Microsoft Cloud Show](http://www.microsoftcloudshow.com/podcast): A weekly podcast on Microsoft Cloud and its applications. 
+- [Kubernetes Podcast from Google](https://kubernetespodcast.com/): A weekly podcast focused on what's happening in the Kubernetes community covering Kubernetes, cloud-native applications, and other developments in the Kubernetes community. Co-hosts Adam Glick and Craig Box.
+- [Microsoft Cloud Show](http://www.microsoftcloudshow.com/podcast): A weekly podcast on Microsoft Cloud and its applications.
 
 ## Design
 
@@ -78,11 +78,11 @@
 ## Mindset/Self-Development
 
 - [Developer Tea](https://spec.fm/podcasts/developer-tea): Provides advice and tips on becoming a better developer.
-- [Rob Dial](https://robdial.com/podcast/):Mindset Mentor talks about self-development in short 15 minutes talks 
+- [Rob Dial](https://robdial.com/podcast/):Mindset Mentor talks about self-development in short 15 minutes talks
 - [Degree Free](https://degreefree.co/podcast/): Getting your dream job does not always require a degree but having the motivation and resources to get there is where Degree Free Podcast comes to fruitation in your life.
 - [The Daily Job Hunt by Career Hackers](https://careerhackers.com/podcast/): This 3-minute daily podcast is the audio version of the same email, written and read by Joel Bein. The DJH shares advice no one taught you in school. In fact, it is the antidote to the damage school caused. Get curious, get creative, and get empowered.
-- [Huberman Lab](https://podtail.com/podcast/huberman-lab/): Huberman Lab discusses neuroscience: how our brain and its connections with the organs of our body control our perceptions, our behaviors, and our health in a way anyone can use it to  his/her own benefit
-  
+- [Huberman Lab](https://podtail.com/podcast/huberman-lab/): Huberman Lab discusses neuroscience: how our brain and its connections with the organs of our body control our perceptions, our behaviors, and our health in a way anyone can use it to his/her own benefit
+
 ## InfoSec / CyberSecurity
 
 - [Darknet Diaries](https://darknetdiaries.com/): Darknet Diaries is a podcast covering true stories from the dark side of the Internet. Stories about hackers, defenders, threats, malware, botnets, breaches, and privacy.
@@ -95,12 +95,13 @@
 - [Podcast.**init**](https://www.pythonpodcast.com/): Every week a new episode provides useful and informative insights into the projects, platforms, and practices that engineers, business leaders, and data scientists need to know about to learn and grow in their career.
 - [Real Python Talk](https://realpython.com/podcasts/rpp/): A weekly Python podcast hosted by Christopher Bailey with interviews, coding tips, and conversation with guests from the Python community. The show covers a wide range of topics including Python programming best practices, career tips, and related software development topics.
 
-
-
-
 ## Computer Science topics
 
 - [Base.cs Podcast](https://www.codenewbie.org/basecs): Beginner-friendly computer science lessons based on Vaidehi Joshi's base.cs blog series, produced by CodeNewbie.
 - [Software Engineering daily](https://softwareengineeringdaily.com/) Software development topics including technical interviews.
-- [No BS Engineering](https://nobsengineering.com/): General career advice for beginner to intermediate-level coders. 
+- [No BS Engineering](https://nobsengineering.com/): General career advice for beginner to intermediate-level coders.
 - [Computer Science/Software Engineering College Courses Review](https://player.fm/series/computer-sciencesoftware-engineering-college-courses-review): A series covering the key courses needed for a computer science degree.
+
+## Product Management and Design
+
+- [Product Talk](https://podcasts.apple.com/us/podcast/product-talk/id1038890550): A podcast for anyone interested in product management, design, and building successful products. The show features interviews with industry leaders, discussions on emerging trends, and practical advice to help you create and launch amazing products.


### PR DESCRIPTION
## Resource name and link
[Product Talk](https://podcasts.apple.com/us/podcast/product-talk/id1038890550)

## Short description
Product Talk is a podcast focused on product management, design, and building successful products. It features interviews with industry leaders, emerging trends, and actionable advice for product development.

## Why do you think this is a good resource?
This podcast is a valuable resource for the community as it provides insightful, practical advice from top industry professionals, helping listeners stay updated on the latest trends and best practices in product management and design.
