### PR TITLE
docs: add Hanzilla Canada developer jobs resource

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,6 +8,7 @@
 
 This is a list showing the GitHub usernames of all who have contributed to this open-source project! **Make sure to add yourself and submit a pull request if you've contributed.**
 
+- [@hanzili](https://github.com/hanzili)
 - [@8xu](https://github.com/8xu)
 - [@surajdm123](https://github.com/surajdm123)
 - [@navidcodes](https://github.com/navidcodes)

--- a/HowtoInterviewforCodeJobs.md
+++ b/HowtoInterviewforCodeJobs.md
@@ -24,6 +24,8 @@
 
 - [Tech Interview Handbook](https://yangshun.github.io/tech-interview-handbook/): Carefully curated content to help you ace your next technical interview!
 
+- [Hanzilla Jobs](https://jobs.hanzilla.co/categories/software-engineering/): A free daily-updated Canadian student and recent-graduate job board for software engineering internships, co-ops, new grad, junior, and entry-level roles.
+
 ### Guides
 
 - [How to Write A Killer Software Engineering Résumé](https://medium.freecodecamp.org/writing-a-killer-software-engineering-resume-b11c91ef699d): A fantastic breakdown of the essential components that make up a résumé. The impact statements within the **_Employment_** and **_Project_** sections in particular are especially worthwhile. Highly recommended as virtually every company requires them, whether or not you use résumés to get your job.


### PR DESCRIPTION
## Summary
- Adds Hanzilla Jobs to the coding-job interview resources as a Canada-specific student/recent-grad software engineering job board.
- Adds my GitHub handle to the contributors list, per the contribution guide.

## Why
Hanzilla Jobs is a free, daily-updated Canadian student/recent-grad jobs board. The linked page focuses on software engineering internships, co-ops, new grad, junior, and entry-level roles, so it fits readers using this interview/job-search resource while looking for Canadian opportunities.

## Checks
- Verified the linked Hanzilla software-engineering page returns HTTP 200 and is indexable.
- Ran `git diff --check`.
