### PR TITLE
Add Showcase job-search resource

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,6 +8,7 @@
 
 This is a list showing the GitHub usernames of all who have contributed to this open-source project! **Make sure to add yourself and submit a pull request if you've contributed.**
 
+- [@09Kdyutit](https://github.com/09Kdyutit)
 - [@hanzili](https://github.com/hanzili)
 - [@8xu](https://github.com/8xu)
 - [@surajdm123](https://github.com/surajdm123)

--- a/HowtoInterviewforCodeJobs.md
+++ b/HowtoInterviewforCodeJobs.md
@@ -56,7 +56,7 @@
 
 - [Pramp](https://www.pramp.com/): A free tool built to provide the complete interview practice you need from Technical to behavioral interviews.
 
-- [Showcase](https://app.tryshowcase.ink/?utm_source=github&utm_medium=community_resource&utm_campaign=direct100_20260710&utm_content=zero_to_mastery_resources): Turns a résumé into an editable, evidence-first portfolio with in-account feedback and interview practice. Free accounts can build, edit, and preview privately; publishing requires Pro.
+- [Showcase](https://app.tryshowcase.ink/?utm_source=zero_to_mastery&utm_medium=community_resource&utm_campaign=direct100_20260710&utm_content=resources_interview_tools): Turns a résumé into an editable, evidence-first portfolio with in-account feedback and interview practice. Free accounts can build, edit, and preview privately; publishing requires Pro.
 
 #### Coding Challenges
 

--- a/HowtoInterviewforCodeJobs.md
+++ b/HowtoInterviewforCodeJobs.md
@@ -56,6 +56,8 @@
 
 - [Pramp](https://www.pramp.com/): A free tool built to provide the complete interview practice you need from Technical to behavioral interviews.
 
+- [Showcase](https://app.tryshowcase.ink/?utm_source=github&utm_medium=community_resource&utm_campaign=direct100_20260710&utm_content=zero_to_mastery_resources): Turns a résumé into an editable, evidence-first portfolio with in-account feedback and interview practice. Free accounts can build, edit, and preview privately; publishing requires Pro.
+
 #### Coding Challenges
 
 - [Codewars](https://www.codewars.com/): A place to challenge yourself and hone your coding skills. See if you can find any fellow ZTM students on there and team up!


### PR DESCRIPTION
## Resource name and link

[Showcase](https://app.tryshowcase.ink/?utm_source=zero_to_mastery&utm_medium=community_resource&utm_campaign=direct100_20260710&utm_content=resources_interview_tools)

## Short description

Turns a résumé into an editable, evidence-first portfolio with in-account feedback and interview practice. Free accounts can build, edit, and preview privately; publishing requires Pro.

## Why do you think this is a good resource?

This fits the existing Interviewing Tools section for developers preparing applications and interviews. It helps readers turn their existing project and work evidence into a reviewable portfolio and prepare from the same source material.

I verified that the linked page is live and returns HTTP 200 without redirects.

Disclosure: I am Showcase's founder, so this is a first-party suggestion. Please include it only if it meets the list's editorial standard.

## GitHub repository (optional)

https://github.com/09Kdyutit/Showcase
